### PR TITLE
Using base32 encoding algorithm from BouncyCastle for constant-time b…

### DIFF
--- a/java/src/main/java/org/whispersystems/libsignal/ecc/ECPublicKey.java
+++ b/java/src/main/java/org/whispersystems/libsignal/ecc/ECPublicKey.java
@@ -9,6 +9,7 @@ package org.whispersystems.libsignal.ecc;
 import org.whispersystems.libsignal.InvalidKeyException;
 import org.whispersystems.libsignal.util.Base32;
 import org.whispersystems.libsignal.util.Hex;
+import org.whispersystems.libsignal.util.InvalidCharacterException;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -27,7 +28,15 @@ public class ECPublicKey implements Comparable<ECPublicKey> {
     }
 
     public ECPublicKey(String string) throws InvalidKeyException {
-        this(Base32.humanFriendly.decodeFromString(string));
+        this(decodeFromString(string));
+    }
+
+    private static byte[] decodeFromString(String string) throws InvalidKeyException {
+        try {
+            return Base32.humanFriendly.decodeFromString(string);
+        } catch (InvalidCharacterException ice) {
+            throw new InvalidKeyException(ice);
+        }
     }
 
     public byte[] getBytes() {

--- a/java/src/main/java/org/whispersystems/libsignal/util/Base32.java
+++ b/java/src/main/java/org/whispersystems/libsignal/util/Base32.java
@@ -1,46 +1,39 @@
 package org.whispersystems.libsignal.util;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * An implementation of Base32 encoding/decoding that accepts arbitrary alphabets.
  * From http://www.herongyang.com/Encoding/Base32-Bitpedia-Java-Implementation.html;
- *
+ * <p>
  * It also supports a replacement table on decoding to handle mis-entered letters.
  */
 public class Base32 {
-    private final String alphabet;
+    private static char padding = '=';
+    private static String paddingString = "=";
 
-    private static final int[] base32Lookup = new int[128];
-    private static final int[] replacementLookup = new int[128];
+    private final Map<Character, Character> replacements;
+    private final Base32Encoder encoder;
 
     /**
      * Constructs a new non-padded Base32 encoder with a custom alphabet (must be 32 characters).
-     *
+     * <p>
      * Based on http://www.herongyang.com/Encoding/Base32-Bitpedia-Java-Implementation.html.
      *
      * @param alphabet
      */
-    public Base32(String alphabet, Map<Integer, Integer> replacements) {
+    public Base32(String alphabet, Map<Character, Character> replacements) {
         if (alphabet.length() != 32) {
             throw new RuntimeException("alphabet is not 32-bytes long");
         }
-        this.alphabet = alphabet;
-        for (int i = 0; i < base32Lookup.length; i++) {
-            base32Lookup[i] = 0xFF;
-        }
-        for (int i = 0; i < alphabet.length(); i++) {
-            base32Lookup[(int) alphabet.charAt(i)] = i;
-        }
-        for (int i = 0; i < replacementLookup.length; i++) {
-            replacementLookup[i] = 0xFF;
-        }
-        if (replacements != null) {
-            for (Map.Entry<Integer, Integer> entry : replacements.entrySet()) {
-                replacementLookup[entry.getKey()] = entry.getValue();
-            }
-        }
+        this.replacements = replacements;
+        encoder = new Base32Encoder(alphabet.getBytes(Charset.forName("ASCII")), (byte) padding);
     }
 
     /**
@@ -48,41 +41,23 @@ public class Base32 {
      *
      * @param bytes Bytes to encode.
      * @return Encoded byte array <code>bytes</code> as a String.
-     *
      */
     public String encodeToString(final byte[] bytes) {
-        int i = 0, index = 0, digit = 0;
-        int currByte, nextByte;
-        StringBuffer base32
-                = new StringBuffer((bytes.length + 7) * 8 / 5);
-
-        while (i < bytes.length) {
-            currByte = (bytes[i] >= 0) ? bytes[i] : (bytes[i] + 256);
-
-            /* Is the current digit going to span a byte boundary? */
-            if (index > 3) {
-                if ((i + 1) < bytes.length) {
-                    nextByte = (bytes[i + 1] >= 0)
-                            ? bytes[i + 1] : (bytes[i + 1] + 256);
-                } else {
-                    nextByte = 0;
-                }
-
-                digit = currByte & (0xFF >> index);
-                index = (index + 5) % 8;
-                digit <<= index;
-                digit |= nextByte >> (8 - index);
-                i++;
-            } else {
-                digit = (currByte >> (8 - (index + 5))) & 0x1F;
-                index = (index + 5) % 8;
-                if (index == 0)
-                    i++;
-            }
-            base32.append(alphabet.charAt(digit));
+        int length = bytes.length;
+        int encodedLength = encoder.getEncodedLength(length);
+        ByteArrayOutputStream out = new ByteArrayOutputStream(encodedLength);
+        try {
+            encoder.encode(bytes, 0, length, out);
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
         }
-
-        return base32.toString();
+        try {
+            // Removing padding is not constant time and leaks information about the length of a
+            // value.
+            return out.toString("ASCII").replace(paddingString, "");
+        } catch (UnsupportedEncodingException ue) {
+            throw new RuntimeException(ue);
+        }
     }
 
     /**
@@ -92,66 +67,47 @@ public class Base32 {
      * @return Decoded <code>base32</code> String as a raw byte array.
      */
     public byte[] decodeFromString(final String base32) {
-        int i, index, lookup, offset, digit, replacement;
-        byte[] bytes = new byte[base32.length() * 5 / 8];
-
-        for (i = 0, index = 0, offset = 0; i < base32.length(); i++) {
-            lookup = base32.charAt(i);
-
-            /* Guard against unrecognized characters */
-            if (lookup < 0 || lookup >= base32Lookup.length) {
-                throw new InvalidCharacterException((char) lookup);
+        int encodedLength = base32.length();
+        int paddedLength = (int) Math.ceil(((double) encodedLength) / 8.0) * 8;
+        final StringBuilder base32Builder = new StringBuilder(paddedLength);
+        for (char c : base32.toCharArray()) {
+            // This is not constant time, but it only applies if people have manually fat-fingered
+            // a character.
+            Character c2 = replacements.get(c);
+            if (c2 == null) {
+                c2 = c;
             }
-
-            /* Replace characters using the replacement table */
-            replacement = replacementLookup[lookup];
-            if (replacement != 0xFF) {
-                lookup = replacement;
-            }
-
-            digit = base32Lookup[lookup];
-
-            /* If this digit is not in the table, throw an exception */
-            if (digit == 0xFF) {
-                throw new InvalidCharacterException((char) lookup);
-            }
-
-            if (index <= 3) {
-                index = (index + 5) % 8;
-                if (index == 0) {
-                    bytes[offset] |= digit;
-                    offset++;
-                    if (offset >= bytes.length)
-                        break;
-                } else {
-                    bytes[offset] |= digit << (8 - index);
-                }
-            } else {
-                index = (index + 5) % 8;
-                bytes[offset] |= (digit >>> index);
-                offset++;
-
-                if (offset >= bytes.length) {
-                    break;
-                }
-                bytes[offset] |= digit << (8 - index);
-            }
+            base32Builder.append(c2);
         }
-        return bytes;
+        int requiredPadding = paddedLength - encodedLength;
+        for (int i = 0; i < requiredPadding; i++) {
+            // This is not constant time and leaks information about the length of a value.
+            base32Builder.append(padding);
+        }
+        final String modified = base32Builder.toString();
+        int length = modified.length() / 8 * 5;
+        ByteArrayOutputStream out = new ByteArrayOutputStream(length);
+        try {
+            encoder.decode(modified, out);
+            return out.toByteArray();
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
     }
 
     // This alphabet is based on the z-base-32 alphabet which preferences characters that are easier
     // for humans to read. It omits the number 0 and the letters i, l and v. On decoding, we also
     // map the letters i and l to the number 1 and the number 0 to the letter o.
     private static final String humanFriendlyAlphabet = "ybndrfg8ejkmcpqxot1uw2sza345h769";
-    private static final Map<Integer, Integer> replacements = new HashMap<Integer, Integer>();
+    private static final Map<Character, Character> humanFriendlyReplacements = new HashMap<>();
 
     static {
         // map some commonly fat-fingered characters to their correct replacements
-        replacements.put((int) 'i', (int) '1');
-        replacements.put((int) 'l', (int) '1');
-        replacements.put((int) '0', (int) 'o');
+        humanFriendlyReplacements.put('i', '1');
+        humanFriendlyReplacements.put('l', '1');
+        humanFriendlyReplacements.put('0', 'o');
     }
 
-    public static final Base32 humanFriendly = new Base32(humanFriendlyAlphabet, replacements);
+    public static final Base32 humanFriendly =
+            new Base32(humanFriendlyAlphabet, humanFriendlyReplacements);
 }

--- a/java/src/main/java/org/whispersystems/libsignal/util/Base32Encoder.java
+++ b/java/src/main/java/org/whispersystems/libsignal/util/Base32Encoder.java
@@ -1,0 +1,445 @@
+package org.whispersystems.libsignal.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * A streaming Base32 encoder.
+ *
+ * Copied from org.bouncycastle.util.encoders.Base32Encoder, available at
+ * https://github.com/bcgit/bc-java/blob/master/core/src/main/java/org/bouncycastle/util/encoders/Base32Encoder.java.
+ */
+public class Base32Encoder
+{
+    /*
+     * set up the decoding table.
+     */
+    private final byte[] encodingTable;
+    private final byte   padding;
+    private final byte[] decodingTable = new byte[128];
+
+    protected void initialiseDecodingTable()
+    {
+        for (int i = 0; i < decodingTable.length; i++)
+        {
+            decodingTable[i] = (byte)0xff;
+        }
+
+        for (int i = 0; i < encodingTable.length; i++)
+        {
+            decodingTable[encodingTable[i]] = (byte)i;
+        }
+    }
+
+    /**
+     * Constructor allowing the setting of an alternative alphabet.
+     *
+     * @param encodingTable a 32 entry encoding table to do the mapping.
+     * @param padding the padding value to use.
+     */
+    public Base32Encoder(byte[] encodingTable, byte padding)
+    {
+        if (encodingTable.length != 32)
+        {
+            throw new IllegalArgumentException("encoding table needs to be length 32");
+        }
+
+        this.encodingTable = encodingTable.clone();
+        this.padding = padding;
+
+        initialiseDecodingTable();
+    }
+
+    public int encode(byte[] inBuf, int inOff, int inLen, byte[] outBuf, int outOff) throws IOException
+    {
+        int inPos = inOff;
+        int inEnd = inOff + inLen - 4;
+        int outPos = outOff;
+
+        while (inPos < inEnd)
+        {
+            encodeBlock(inBuf, inPos, outBuf, outPos);
+            inPos += 5;
+            outPos += 8;
+        }
+
+        int extra = inLen - (inPos - inOff);
+        if (extra > 0)
+        {
+            byte[] in = new byte[5];
+            System.arraycopy(inBuf, inPos, in, 0, extra);
+            encodeBlock(in, 0, outBuf, outPos);
+            switch (extra)
+            {
+                case 1:
+                    outBuf[outPos + 2] = padding;
+                    outBuf[outPos + 3] = padding;
+                    outBuf[outPos + 4] = padding;
+                    outBuf[outPos + 5] = padding;
+                    outBuf[outPos + 6] = padding;
+                    outBuf[outPos + 7] = padding;
+                    break;
+                case 2:
+                    outBuf[outPos + 4] = padding;
+                    outBuf[outPos + 5] = padding;
+                    outBuf[outPos + 6] = padding;
+                    outBuf[outPos + 7] = padding;
+                    break;
+                case 3:
+                    outBuf[outPos + 5] = padding;
+                    outBuf[outPos + 6] = padding;
+                    outBuf[outPos + 7] = padding;
+                    break;
+                case 4:
+                    outBuf[outPos + 7] = padding;
+                    break;
+            }
+
+            outPos += 8;
+        }
+
+        return outPos - outOff;
+    }
+
+    private void encodeBlock(byte[] inBuf, int inPos, byte[] outBuf, int outPos)
+    {
+        int a1 = inBuf[inPos++];
+        int a2 = inBuf[inPos++] & 0xFF;
+        int a3 = inBuf[inPos++] & 0xFF;
+        int a4 = inBuf[inPos++] & 0xFF;
+        int a5 = inBuf[inPos] & 0xFF;
+
+        outBuf[outPos++] = encodingTable[(a1 >>> 3) & 0x1F];
+        outBuf[outPos++] = encodingTable[((a1 << 2) | (a2 >>> 6)) & 0x1F];
+        outBuf[outPos++] = encodingTable[(a2 >>> 1) & 0x1F];
+        outBuf[outPos++] = encodingTable[((a2 << 4) | (a3 >>> 4)) & 0x1F];
+        outBuf[outPos++] = encodingTable[((a3 << 1) | (a4 >>> 7)) & 0x1F];
+        outBuf[outPos++] = encodingTable[(a4 >>> 2) & 0x1F];
+        outBuf[outPos++] = encodingTable[((a4 << 3) | (a5 >>> 5)) & 0x1F];
+        outBuf[outPos] = encodingTable[a5 & 0x1F];
+    }
+
+    public int getEncodedLength(int inputLength)
+    {
+        return (inputLength + 4) / 5 * 8;
+    }
+
+    public int getMaxDecodedLength(int inputLength)
+    {
+        return inputLength / 8 * 5;
+    }
+
+    /**
+     * encode the input data producing a base 32 output stream.
+     *
+     * @return the number of bytes produced.
+     */
+    public int encode(byte[] buf, int off, int len, OutputStream out)
+            throws IOException
+    {
+        if (len < 0)
+        {
+            return 0;
+        }
+
+        byte[] tmp = new byte[72];
+        int remaining = len;
+        while (remaining > 0)
+        {
+            int inLen = Math.min(45, remaining);
+            int outLen = encode(buf, off, inLen, tmp, 0);
+            out.write(tmp, 0, outLen);
+            off += inLen;
+            remaining -= inLen;
+        }
+        return (len + 2) / 3 * 4;
+    }
+
+    private boolean ignore(
+            char    c)
+    {
+        return (c == '\n' || c =='\r' || c == '\t' || c == ' ');
+    }
+
+    /**
+     * decode the base 32 encoded byte data writing it to the given output stream,
+     * whitespace characters will be ignored.
+     *
+     * @return the number of bytes produced.
+     */
+    public int decode(
+            byte[]          data,
+            int             off,
+            int             length,
+            OutputStream    out)
+            throws IOException
+    {
+        byte    b1, b2, b3, b4, b5, b6, b7, b8;
+        byte[]  outBuffer = new byte[55];
+        int     bufOff = 0;
+        int     outLen = 0;
+
+        int     end = off + length;
+
+        while (end > off)
+        {
+            if (!ignore((char)data[end - 1]))
+            {
+                break;
+            }
+
+            end--;
+        }
+
+        // empty data!
+        if (end == 0)
+        {
+            return 0;
+        }
+
+        int  i = 0;
+        int  finish = end;
+
+        while (finish > off && i != 8)
+        {
+            if (!ignore((char)data[finish - 1]))
+            {
+                i++;
+            }
+
+            finish--;
+        }
+
+        i = nextI(data, off, finish);
+
+        while (i < finish)
+        {
+            b1 = decodingTable[data[i++]];
+
+            i = nextI(data, i, finish);
+
+            b2 = decodingTable[data[i++]];
+
+            i = nextI(data, i, finish);
+
+            b3 = decodingTable[data[i++]];
+
+            i = nextI(data, i, finish);
+
+            b4 = decodingTable[data[i++]];
+
+            i = nextI(data, i, finish);
+
+            b5 = decodingTable[data[i++]];
+
+            i = nextI(data, i, finish);
+
+            b6 = decodingTable[data[i++]];
+
+            i = nextI(data, i, finish);
+
+            b7 = decodingTable[data[i++]];
+
+            i = nextI(data, i, finish);
+
+            b8 = decodingTable[data[i++]];
+
+            if ((b1 | b2 | b3 | b4 | b5 | b6 | b7 | b8) < 0)
+            {
+                throw new InvalidCharacterException("invalid characters encountered in base32 data");
+            }
+
+            outBuffer[bufOff++] = (byte)((b1 << 3) | (b2 >> 2));
+            outBuffer[bufOff++] = (byte)((b2 << 6) | (b3 << 1) | (b4 >> 4));
+            outBuffer[bufOff++] = (byte)((b4 << 4) | (b5 >> 1));
+            outBuffer[bufOff++] = (byte)((b5 << 7) | (b6 << 2) | (b7 >> 3));
+            outBuffer[bufOff++] = (byte)((b7 << 5) | b8);
+
+            if (bufOff == outBuffer.length)
+            {
+                out.write(outBuffer);
+                bufOff = 0;
+            }
+
+            outLen += 5;
+
+            i = nextI(data, i, finish);
+        }
+
+        if (bufOff > 0)
+        {
+            out.write(outBuffer, 0, bufOff);
+        }
+
+        int e0 = nextI(data, i, end);
+        int e1 = nextI(data, e0 + 1, end);
+        int e2 = nextI(data, e1 + 1, end);
+        int e3 = nextI(data, e2 + 1, end);
+        int e4 = nextI(data, e3 + 1, end);
+        int e5 = nextI(data, e4 + 1, end);
+        int e6 = nextI(data, e5 + 1, end);
+        int e7 = nextI(data, e6 + 1, end);
+
+        outLen += decodeLastBlock(out,
+                (char)data[e0], (char)data[e1], (char)data[e2], (char)data[e3],
+                (char)data[e4], (char)data[e5], (char)data[e6], (char)data[e7]);
+
+        return outLen;
+    }
+
+    private int nextI(byte[] data, int i, int finish)
+    {
+        while ((i < finish) && ignore((char)data[i]))
+        {
+            i++;
+        }
+        return i;
+    }
+
+    /**
+     * decode the base 32 encoded String data writing it to the given output stream,
+     * whitespace characters will be ignored.
+     *
+     * @return the number of bytes produced.
+     */
+    public int decode(
+            String          data,
+            OutputStream    out)
+            throws IOException
+    {
+        byte[] bytes = toByteArray(data);
+        return decode(bytes, 0, bytes.length, out);
+    }
+
+    private int decodeLastBlock(OutputStream out,
+                                char c1, char c2, char c3, char c4,
+                                char c5, char c6, char c7, char c8)
+            throws IOException
+    {
+        byte    b1, b2, b3, b4, b5, b6, b7, b8;
+
+        if (c8 == padding)
+        {
+            if (c7 != padding)
+            {
+                b1 = decodingTable[c1];
+                b2 = decodingTable[c2];
+                b3 = decodingTable[c3];
+                b4 = decodingTable[c4];
+                b5 = decodingTable[c5];
+                b6 = decodingTable[c6];
+                b7 = decodingTable[c7];
+
+                if ((b1 | b2 | b3 | b4 | b5 | b6 | b7) < 0)
+                {
+                    throw new InvalidCharacterException("invalid characters encountered at end of base32 data");
+                }
+
+                out.write((b1 << 3) | (b2 >> 2));
+                out.write((b2 << 6) | (b3 << 1) | (b4 >> 4));
+                out.write((b4 << 4) | (b5 >> 1));
+                out.write((b5 << 7) | (b6 << 2) | (b7 >> 3));
+
+                return 4;
+            }
+            if (c6 != padding)
+            {
+                throw new InvalidCharacterException("invalid characters encountered at end of base32 data");
+            }
+
+            if (c5 != padding)
+            {
+                b1 = decodingTable[c1];
+                b2 = decodingTable[c2];
+                b3 = decodingTable[c3];
+                b4 = decodingTable[c4];
+                b5 = decodingTable[c5];
+
+                if ((b1 | b2 | b3 | b4 | b5) < 0)
+                {
+                    throw new InvalidCharacterException("invalid characters encountered at end of base32 data");
+                }
+
+                out.write((b1 << 3) | (b2 >> 2));
+                out.write((b2 << 6) | (b3 << 1) | (b4 >> 4));
+                out.write((b4 << 4) | (b5 >> 1));
+
+                return 3;
+            }
+
+            if (c4 != padding)
+            {
+                b1 = decodingTable[c1];
+                b2 = decodingTable[c2];
+                b3 = decodingTable[c3];
+                b4 = decodingTable[c4];
+
+                if ((b1 | b2 | b3 | b4) < 0)
+                {
+                    throw new InvalidCharacterException("invalid characters encountered at end of base32 data");
+                }
+
+                out.write((b1 << 3) | (b2 >> 2));
+                out.write((b2 << 6) | (b3 << 1) | (b4 >> 4));
+
+                return 2;
+            }
+
+            if (c3 != padding)
+            {
+                throw new InvalidCharacterException("invalid characters encountered at end of base32 data");
+            }
+
+            b1 = decodingTable[c1];
+            b2 = decodingTable[c2];
+
+            if ((b1 | b2) < 0)
+            {
+                throw new InvalidCharacterException("invalid characters encountered at end of base32 data");
+            }
+
+            out.write((b1 << 3) | (b2 >> 2));
+
+            return 1;
+        }
+        else
+        {
+            b1 = decodingTable[c1];
+            b2 = decodingTable[c2];
+            b3 = decodingTable[c3];
+            b4 = decodingTable[c4];
+            b5 = decodingTable[c5];
+            b6 = decodingTable[c6];
+            b7 = decodingTable[c7];
+            b8 = decodingTable[c8];
+
+            if ((b1 | b2 | b3 | b4 | b5 | b6 | b7 | b8) < 0)
+            {
+                throw new InvalidCharacterException("invalid characters encountered at end of base32 data");
+            }
+
+            out.write((b1 << 3) | (b2 >> 2));
+            out.write((b2 << 6) | (b3 << 1) | (b4 >> 4));
+            out.write((b4 << 4) | (b5 >> 1));
+            out.write((b5 << 7) | (b6 << 2) | (b7 >> 3));
+            out.write((b7 << 5) | b8);
+
+            return 5;
+        }
+    }
+
+    // From import org.bouncycastle.util.Strings
+    private static byte[] toByteArray(String string)
+    {
+        byte[] bytes = new byte[string.length()];
+
+        for (int i = 0; i != bytes.length; i++)
+        {
+            char ch = string.charAt(i);
+
+            bytes[i] = (byte)ch;
+        }
+
+        return bytes;
+    }
+}

--- a/java/src/main/java/org/whispersystems/libsignal/util/InvalidCharacterException.java
+++ b/java/src/main/java/org/whispersystems/libsignal/util/InvalidCharacterException.java
@@ -4,7 +4,7 @@ package org.whispersystems.libsignal.util;
  * Indicates an attempt to Base32 decode a string with an invalid character.
  */
 public class InvalidCharacterException extends RuntimeException {
-    public InvalidCharacterException(char character) {
-        super(String.format("Invalid character %1$c", character));
+    public InvalidCharacterException(String message) {
+        super(message);
     }
 }

--- a/java/src/test/java/org/whispersystems/libsignal/ecc/ECPublicKeyTest.java
+++ b/java/src/test/java/org/whispersystems/libsignal/ecc/ECPublicKeyTest.java
@@ -30,13 +30,13 @@ public class ECPublicKeyTest extends TestCase {
 
     public void testCorrupted() throws InvalidKeyException {
         ECPublicKey key = Curve.generateKeyPair().getPublicKey();
-        String keyString = key.toString() + "=";
+        String keyString = key.toString() + "+";
         try {
             new ECPublicKey(keyString);
-            fail("corrupted key should cause InvalidCharacterException");
-        } catch (InvalidCharacterException ice) {
+            fail("corrupted key should cause InvalidKeyException");
+        } catch (InvalidKeyException ike) {
             // expected
-            System.out.println(ice.toString());
+            System.out.println(ike.toString());
         }
     }
 


### PR DESCRIPTION
…ase32 encoding and usually constant-time base32 decoding

For getlantern/android-lantern#487.

There's a couple of deviations from doing things totally constant-time.

1. We remove/add padding, which could leak information about the length of a value
2. On decoding, to help with fat-fingered values, we replace certain characters with others. As long as someone doesn't fat-finger an entry, this shouldn't leak anything.

- [x] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ ] Can it be QA’d in staging or something like staging?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Do we know how we’re going to deploy this?
- [ ] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?